### PR TITLE
More KISS, less features, still works :)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+linuxmuster-client-servertools (0.8) babo; urgency=low
+
+  * Added consolidate -H (remove -h)
+  * Added wget -c to continue downloads
+  * Added -f to force overwrite files
+  * Renamed the option -l to -p for password
+  * Hiding the option to set the password alone
+  * Added checking of the md5sums 
+  * Removed update-available, unnecessary as command
+  * Rename variable HWCLASS to HOSTGROUP consistently
+  * Renamed exit1 to exit_error consistently
+  * Changed the copying of all ssh-keys to the client
+  * Changed the default password to "muster" analogous to the XEN-VMs
+  * Changed the encoding to utf-8
+
+ -- Tobias Küchel <t.kuechel@humboldt-ka.de>  Fri, 31 Mar 2017 17:52:57 +0100
+
 linuxmuster-client-servertools (0.7) babo; urgency=low
 
   * Moved postsync-template to /usr/lib/linuxmuster-client-servertools

--- a/etc/linuxmuster/client-servertools.conf
+++ b/etc/linuxmuster/client-servertools.conf
@@ -2,14 +2,14 @@
 # Einbindung eines Community gepflegten cloops
 
 # linuxadmin password
-CONF_LINUXADMIN_PW="muster2016"
+CONF_LINUXADMIN_PW="muster"
 
 # Aenderungen von hier ab bitte nur 
 # nach Konsultation der Dokumentation...
 #
 # linbo-Hostgroup als Patchklasse verwenden?
 # default off -> 0
-CONF_HOSTGROUP_AS_PATCHCLASS=0
+#CONF_HOSTGROUP_AS_PATCHCLASS=0
 # Cloop Quelle
 CONF_CLOOP_SERVER="http://cloop.linuxmuster.net/"
 # Vorlage für das generic postsync file

--- a/usr/sbin/linuxmuster-client
+++ b/usr/sbin/linuxmuster-client
@@ -23,9 +23,10 @@ check_startup
 
 PATCHCLASS_SET=0
 COMMONCLASS=""
+FORCE=0
 
 # Optionen verarbeiten
-while getopts ":a:c:p:l:H:" opt; do
+while getopts ":a:c:fp:H:" opt; do
 case $opt in
     a)
         ACTION=$OPTARG
@@ -33,15 +34,18 @@ case $opt in
     c)
         CLOOP_NAME=$OPTARG
         ;;
-    p)	
-	PATCHCLASS_SET=1
-        PATCHCLASS=$OPTARG
-        ;;
-    l)
+    f)
+	FORCE=1
+	;;
+#    P)	
+#	PATCHCLASS_SET=1
+#        PATCHCLASS=$OPTARG
+#        ;;
+    p)
 	LAPASS=$OPTARG
 	;;
     H)
-        HWCLASS=$OPTARG
+        HOSTGROUP=$OPTARG
         ;;
     \?)
         print_help
@@ -53,46 +57,48 @@ done
 
 case $ACTION in
 auto)
-    if [ "x$HWCLASS" == "x" ]; then 
-        exit_error "Die Option -H <hardwareklasse> muss angegeben werden."
-    fi
     if [ "x$CLOOP_NAME" == "x" ]; then
-        exit_error "Die Option -c <CloopName> muss angegeben werden."
+        exit_error "Die Option -c <Imagename> muss angegeben werden. $0 -h für weitere Hilfe."
     fi 
+    # Hardwareklasse wird CLOOP_NAME verwendet, außer es wurde gesetzt
+    HOSTGROUP=${HOSTGROUP:-$CLOOP_NAME}
+    list_available_images $CLOOP_NAME || { list_available_images; exit_error "Konnte kein Cloop mit dem angegebenen Namen ($CLOOP_NAME) finden."; }
 
-    list_available_images $CLOOP_NAME || exit_error "Konnte kein Cloop mit dem angegebenen Namen ($CLOOP_NAME) finden."
-
-    PATCHCLASS_SET=1
-    PATCHCLASS=$HWCLASS
-
+    #PATCHCLASS_SET=1
+    #PATCHCLASS=$HOSTGROUP
 
     # Cloop herunterladen
-    get_remote_cloop $HWCLASS $CLOOP_NAME
+    get_remote_cloop $HOSTGROUP $CLOOP_NAME
     # Cloop konfigurieren
-    configure_cloop ${HWCLASS}.cloop
+    configure_cloop ${HOSTGROUP} $CLOOP_NAME
 
     ;;
 get-cloop)
-    if [ "x$HWCLASS" == "x" ]; then 
-        exit_error "Die Option -H <hardwareklasse> muss angegeben werden."
-    fi
     if [ "x$CLOOP_NAME" == "x" ]; then
-        exit_error "Die Option -c <CloopName> muss angegeben werden."
+        exit_error "Die Option -c <Imagename> muss angegeben werden. $0 -h für weitere Hilfe."
     fi 
-    list_available_images $CLOOP_NAME || exit_error "Konnte kein Cloop mit dem angegebenen Namen ($CLOOP_NAME) finden."
-    get_remote_cloop $HWCLASS $CLOOP_NAME
+    # Hardwareklasse wird CLOOP_NAME verwendet, außer es wurde gesetzt
+    HOSTGROUP=${HOSTGROUP:-$CLOOP_NAME}
+    list_available_images $CLOOP_NAME || { list_available_images; exit_error "Konnte kein Cloop mit dem angegebenen Namen ($CLOOP_NAME) finden."; }
+    get_remote_cloop $HOSTGROUP $CLOOP_NAME
     ;;
 configure)
-    configure_cloop $CLOOP_NAME
+    if [ "x$CLOOP_NAME" == "x" ]; then
+        exit_error "Die Option -c <Imagename> muss angegeben werden. $0 -h für weitere Hilfe."
+    fi 
+    # Hardwareklasse wird CLOOP_NAME verwendet, außer es wurde gesetzt
+    HOSTGROUP=${HOSTGROUP:-$CLOOP_NAME}
+    configure_cloop $HOSTGROUP $CLOOP_NAME
     ;;
 set-postsync-pass)
-    if [ $PATCHCLASS_SET -eq 0 ]; then 
-	PATCHCLASS=""
-    fi
+    if [ "x$HOSTGROUP" == "x" ]; then
+        exit_error "Die Option -H <hardware-class> muss angegeben werden. $0 -h für weitere Hilfe."
+    fi 
+    #if [ $PATCHCLASS_SET -eq 0 ]; then 
+    #	PATCHCLASS=""
+    #fi
+    PATCHCLASS=$HOSTGROUP
     set_password_to_postsync $PATCHCLASS
-    ;;
-update-available)
-    get_available_images
     ;;
 list-available)
     list_available_images

--- a/usr/share/linuxmuster-client-servertools/functions.inc
+++ b/usr/share/linuxmuster-client-servertools/functions.inc
@@ -6,6 +6,9 @@
 # Frank Schiebel <frank@linuxmuster.net>
 # Jesko Anschuetz <jesko|linuxmuster.net>
 
+ts=$(date +%Y%m%d-%H%M%S)
+
+
 #
 # Farbige Ausgabe
 # @Argumente
@@ -52,69 +55,40 @@ function exit_error {
 function print_help() {
 cat <<End-of-help
 Anwendung:
-    $0 [-a action]
-Aktionsauswahl:
-    -a auto -c <cloop-name> -H <hardware-class>
+    $0 -a list-available
+        Aktualisiert die Liste aller verfügbaren cloops und zeigt sie an.
+
+    $0 -a auto -c <Imagename> [-H <hardware-class>] [-p <password>]
         Automatischer Modus, versucht das cloop aus dem Netz vollautomatisch zu installieren
-	Es müssen zwei weitere Optionen angegeben werden:
-	    -c <cloop-name>  wie im Listing der verfügbaren Cloops angezeigt.
-	    -H <HWKlasse>   eine nicht existierende HW-Klasse, für die das Cloop 
-                            konfiguriert wird.
-    -a get-cloop -c <cloop-name> -H <hardware-class>
-        Holt ein cloop aus dem Netz und speichert die nötigen dateien in /var/linbo/ ab. 
-        Bei Konflikten mit vorhandenen Dateien wird der Benutzer informiert, es werden
-        keine Daten überschrieben 
-    -a configure  
+        <Imagename> muss einer der verfügbaren Cloops sein. Hardwareklasse und Passwort sind optional.
+
+    $0 -a get-cloop -c <Imagename> [-H <hardware-class>]
+        Holt ein cloop aus dem Netz und speichert die nötigen dateien in ${CONF_LINBODIR} ab.
+        Ist die Hardwareklasse nicht angegeben wird eine Datei start.conf.<Imagename> erstellt.
+
+    $0 -a configure -c <Imagename> [-H <hardware-class>] [-p <password>]
         Bereitet ein heruntergeladenes cloop-Dateiset mit einem passenden postsync 
-        Skript zur Synchronisation auf Clients vor
-    -a update-available
-        Aktualisiert die Liste verfügbarer cloops vom Server.
-    -a list-available
-        Listet die verfügbaren cloops auf. Aktualisiert zuvor die Liste der verfügbaren 
-        cloops vom Server.  
-    -a set-postsync-pass
-        Setzt das Passwort des Benutzers linuxadmin bei der mit der Option -p angegebenen
-	Patchklasse auf den Wert in der Konfigurationsdatei. Wird mit der Option -l ein 
-	Passwort übergeben, wird dieses für die angegebene Patchklasse gesetzt.
-
+        Skript zur Synchronisation auf Clients vor. Setzt das Passwort des Benutzers linuxadmin 
+	in der Hardwareklasse auf das mit -p angegebene Passwort, andernfalls auf den Wert in der 
+        Konfigurationsdatei.
+          
 Optionen:
-    -H <hardware-class>  
-            Legt unter verwendung des heruntergeladenen cloops 
-            eine Konfiguration mit dem angegebenen Namen an.
-    -c <cloop-Dateiname>
-            Kann bei der Aktion "configure" angegeben werden. Name der 
-            cloop-Datei ohne den Pfad /var/linbo
-    -p <patchklasse> 
-            Legt die Standard-Postyncpatches im UVZ /var/linbo/linuxmuster-client/<patchklasse> an.
-    -l <Passwort>
-            Ermöglicht es, das Passwort einer Patchklasse manuell zu setzen. 
+    -f                   überschreibe alle Dateien und fahre mit dem Download fort, autobackup start.conf
+    -c <Imagename>      welches cloop aus dem Netz verwendet wird
+    -H <hardware-class>  für welche Hardwareklasse das cloop heruntergeladen und konfiguriert wird
+    -p <password>        Ermöglicht es, das Passwort einer Hardwareklasse manuell zu setzen. 
 
-    Beispiele:
+    Beispiel:
 
      $0 -a auto -H myxenial -c xenial916
     
      Holt das Image "xenial916" vom linuxmuster-Server und legt anschließend eine HW-Klasse "myxenial" an, 
-     die das Image verwendet. 
-     Die Postsync-Einstellungen und Skripte werden im Verzeichnis
-        /var/linbo/linuxmuster-client/myxenial/
+     die das Image verwendet. Die Postsync-Einstellungen und Skripte werden im Verzeichnis
+        ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/myxenial/
      angelegt. 
      Das Passwort für linuxadmin wird bei der Synchronisation auf den in der Konfigurationsdatei 
      vorgegebenen Wert gesetzt.
 
-
-     $0 -a set-postsync-pass -l geheim -p mypatchclass
-
-     Ändert das Passwort des linuxadmin für das Cloop, dessen Postsync-Skripte im Verzeichnis 
-         /var/linbo/linuxmuster-client/mypatchclass/
-     liegen auf den Wert "geheim"
-
-
-     $0 -a configure -H myubuntu -p mypatches -c trusty714.cloop
-
-     Konfiguriert das vorhandene Cloop trusty714.cloop als 
-     Hardwareklasse "myubuntu" mit einem universellen postsync Skript, 
-     verwendet dafür das Patchklassenverzeichnis 
-     /var/linbo/linuxmuster-client/mypatches 
 End-of-help
 }
 
@@ -126,14 +100,12 @@ End-of-help
 function check_startup {
     # Are we root?
     if [[ ! "$USER" == "root" ]]; then
-        echo "Dieses Skript muss als root laufen. Abbruch."
-        exit 1
+        exit_error "Dieses Skript muss als root laufen. Abbruch."
     fi
 
     # Gibt es das linbo-Verzeichnis?
     if [[ ! -d ${CONF_LINBODIR} ]]; then
-        echo "Das angegebene Linboverzeichnis existiert nicht. Abbruch"
-        exit 1
+        exit_error "Das angegebene Linboverzeichnis existiert nicht. Abbruch"
     fi
 }
 
@@ -149,7 +121,7 @@ function get_available_images {
 }
 
 # 
-# Listet die  aktuell verfügbaren Online-Images au, wenn kein Argument uebergeben wird
+# Listet die  aktuell verfügbaren Online-Images auf, wenn kein Argument uebergeben wird
 # Wenn eine Argument uebergeben wird, wird getestet, ob es ein Image 
 # mit diesem Namen gibt.
 #
@@ -186,17 +158,18 @@ function list_available_images {
 # Erzeugt ein Array mit den Zieldateien
 # @Argumente
 # $1 hardwareklasse
+# $2 Imagename
 # @Anwendung
-# get_target_fileset mylinux
+# get_target_fileset myxenial xenial916
 #
 function get_target_fileset {
     TARGET_FILESET["startconf"]=${CONF_LINBODIR}/start.conf.$1 
-    TARGET_FILESET["cloop"]=${CONF_LINBODIR}/$1.cloop 
+    TARGET_FILESET["cloop"]=${CONF_LINBODIR}/$2.cloop 
     for key in postsync desc macct; do 
-        TARGET_FILESET["$key"]=${CONF_LINBODIR}/$1.cloop.$key 
+        TARGET_FILESET["$key"]=${CONF_LINBODIR}/$2.cloop.$key 
     done
     for key in md5sums md5sig; do 
-        TARGET_FILESET["$key"]=${CONF_LINBODIR}/$1_hashes.$key 
+        TARGET_FILESET["$key"]=${CONF_LINBODIR}/$2_hashes.$key 
     done
 }
 
@@ -205,7 +178,7 @@ function get_target_fileset {
 # @Argumente
 # $1 Remote cloop Name
 # @Anwendung
-# get_source_fileset trusty714
+# get_source_fileset xenial914
 #
 function get_source_fileset {
     SOURCE_FILESET["startconf"]=start.conf.$1 
@@ -223,115 +196,124 @@ function get_source_fileset {
 # @Argumente
 # $1 hardwareklasse
 # @Anwendung
-# check_conflicting_files mylinux
+# check_conflicting_files myxenial
 #
 function check_target_fileset {
     stop="0";
-    for key in startconf cloop desc macct; do 
+    for key in startconf cloop desc macct md5sums md5sig; do 
         if [ -e ${TARGET_FILESET["$key"]} ]; then 
             echo "Die Datei ${TARGET_FILESET["$key"]}  existiert bereits."
             stop="1"
         fi
     done
-    if [ "x$stop" == "x1" ]; then 
-        colorecho "red" "Werde keine Dateien überschreiben, lösen Sie den Konflikt bitte zuerst auf"
-        exit 1
+    if [ $FORCE -ne 1 ]; then 
+	if [ "x$stop" == "x1" ]; then 
+            colorecho "red" "Werde keine Dateien überschreiben, lösen Sie den Konflikt bitte zuerst auf"
+            colorecho "red" "Oder verwenden Sie -f (--force), um alle Dateien zu überschreiben."
+            exit 1
+	fi
     fi
 }
 
-#
+#nnnnnnn
 # Hole die Cloop-Dateien vom cloop-Server
 # @Argumente
 # $1  Hardwareklasse
 # $2 Remote Cloop Name
 #
 function get_remote_cloop {
-    get_target_fileset $1
     cloop_name=${2%.cloop}
+    get_target_fileset $1 $cloop_name
     get_source_fileset $cloop_name
     check_target_fileset
+
+    STARTCONF=${TARGET_FILESET["startconf"]};
+    if [ -f $STARTCONF ]; then
+        echo "INFO: Sichere $STARTCONF nach $STARTCONF ${STARTCONF}.$ts.autobackup"
+        cp $STARTCONF ${STARTCONF}.$ts.autobackup
+    fi
 
     for key in startconf cloop desc macct md5sums md5sig; do 
         echo "Hole ${TARGET_FILESET[$key]} von"
         echo "     ${CONF_CLOOP_SERVER}/cloops/$cloop_name/${SOURCE_FILESET[$key]}"
-        if wget ${CONF_CLOOP_SERVER}/cloops/$cloop_name/${SOURCE_FILESET[$key]} -O ${TARGET_FILESET[$key]}; then 
+        if wget -c ${CONF_CLOOP_SERVER}/cloops/$cloop_name/${SOURCE_FILESET[$key]} -O ${TARGET_FILESET[$key]}; then 
             colorecho "green" "Success."
         else 
             colorecho "red" "Failed"
-            rm -f ${TARGET_FILESET[$key]}
+            #rm -f ${TARGET_FILESET[$key]}
         fi
     done
+    echo "INFO: Überprüfe download"
+    md5sum -c ${TARGET_FILESET["md5sums"]} --status
+    if [ $? -eq 0 ]; then
+ 	colorecho "green" "Success."
+    else
+	colorecho "red" "Failed"
+	md5sum -c ${TARGET_FILESET["md5sums"]} 
+	exit_error "Lösche die entsprechenden Dateien und versuche es erneut."
+    fi
 }
 
 #
-# Sets password hash to posytsync file
+# Sets password hash to postsync file
 # $1 Name der Patchklasse
 #
 function set_password_to_postsync {
-    if [ x$1 == "x" ]; then 
-        echo "ERROR: Zum setzen eines neuen Passworts muss die Patchklasse angegeben werden"
-        exit 1
-    fi
-    if [ ! -d /var/linbo/linuxmuster-client/$1/common/ ]; then 
-        echo "ERROR: Das Verzeichnis /var/linbo/linuxmuster-client/$1/common/ existiert nicht."
-        echo "ERROR: Die Patchklasse $1 gibt es nicht!"
-        exit 1
+    #if [ x$1 == "x" ]; then 
+    #    echo "ERROR: Zum setzen eines neuen Passworts muss die Patchklasse angegeben werden"
+    #    exit 1
+    #fi
+    if [ ! -d ${CONF_LINBODIR}/linuxmuster-client/$1/common/ ]; then 
+        echo "ERROR: Das Verzeichnis ${CONF_LINBODIR}/linuxmuster-client/$1/common/ existiert nicht."
+        echo "ERROR: Die Hardwareklasse $1 gibt es nicht?!"
+	exit_error "Failed. Aborting."
     fi
 
     if [ x$LAPASS == "x" ]; then 
         # postsync konfiguration anpassen
         # linuxadmin-Passworthash aus der Konfiguration bestimmen und für das postsync Skript bereitstellen
+	echo "INFO: Setze Passwort auf Konfigurationswert"
         PWHASH=$(echo "$CONF_LINUXADMIN_PW" | makepasswd --clearfrom=- --crypt-md5 |awk '{ print $2 }')
-        echo "linuxadmin|$PWHASH" > /var/linbo/linuxmuster-client/$1/common/passwords
+        echo "linuxadmin|$PWHASH" > ${CONF_LINBODIR}/linuxmuster-client/$1/common/passwords
     else 
+	echo "INFO: Setze Passwort auf Kommandozeilenwert"
         PWHASH=$(echo "$LAPASS" | makepasswd --clearfrom=- --crypt-md5 |awk '{ print $2 }')
-        echo "linuxadmin|$PWHASH" > /var/linbo/linuxmuster-client/$1/common/passwords
+        echo "linuxadmin|$PWHASH" > ${CONF_LINBODIR}/linuxmuster-client/$1/common/passwords
     fi
 }
 
 
 #
 # @Argumente
-# $1  Name der cloop-Datei, die eingerichtet werden soll
+# $1  Hardwareklasse
+# $2  Name der cloop-Datei, die eingerichtet werden soll
 #
 function configure_cloop {
+    CLOOP_NAME=${2%.cloop}
     # Gibt es das Cloop?
-    if [ ! -e $CONF_LINBODIR/$1 ]; then 
-        echo "Cloop Datei nicht gefunden: $CONF_LINBODIR/$1"
-        exit 1
+    if [ ! -e $CONF_LINBODIR/${CLOOP_NAME}.cloop ]; then 
+        echo "Cloop Datei nicht gefunden: $CONF_LINBODIR/${CLOOP_NAME}.cloop"
+	exit_error "Failed. Aborting."
     fi
 
-    echo "INFO: Cloop-Datei ist $CONF_LINBODIR/$1"
+    echo "INFO: Cloop-Datei ist $CONF_LINBODIR/${CLOOP_NAME}.cloop"
 
-    CLOOP_HWCLASS=${1%.cloop}
-    STARTCONF_SRC=$CONF_LINBODIR/start.conf.$CLOOP_HWCLASS
-    if [ ! -e $STARTCONF_SRC ]; then 
-        echo "ERROR: Keine start.conf Vorlage für cloop $CLOOP_HWCLASS gefunden"
-        exit 1
+    HOSTGROUP=${1}
+    STARTCONF=$CONF_LINBODIR/start.conf.$HOSTGROUP
+    if [ ! -e $STARTCONF ]; then 
+        echo "WARNING: Keine start.conf für $HOSTGROUP gefunden"
+	exit_error "Failed. Aborting."
     fi
-
-    if [ $HWCLASS == "" ]; then
-        HWCLASS=$CLOOP_HWCLASS
-    fi
-    
-    STARTCONF=$CONF_LINBODIR/start.conf.$HWCLASS
-    echo "INFO: start.conf Quelle ist $STARTCONF_SRC"
-    echo "INFO: start.conf Ziel ist $STARTCONF"
-    ts=$(date +%Y%m%d-%H%M%S)
     if [ -f $STARTCONF ]; then
         echo "INFO: Sichere $STARTCONF nach $STARTCONF ${STARTCONF}.$ts.autobackup"
         cp $STARTCONF ${STARTCONF}.$ts.autobackup
     fi
-    if [  "$STARTCONF_SRC" != "$STARTCONF" ]; then 
-    	cp $STARTCONF_SRC $STARTCONF
-    fi
-
-    echo "INFO: Passe $STARTCONF an"
 
     # start.conf anpassen
+    echo "INFO: Passe $STARTCONF an"
     sed -i "s/\(Server\s*\=\s*\) \(.*\)/\1 $serverip/" $STARTCONF
-    sed -i "s/\(Group\s*\=\s*\) \(.*\)/\1 $HWCLASS/" $STARTCONF
-    sed -i "s/\(BaseImage\s*\=\s*\) \(.*\)/\1 $1/" $STARTCONF
+    sed -i "s/\(Group\s*\=\s*\) \(.*\)/\1 $HOSTGROUP            #Hardwareklasse/" $STARTCONF
+    sed -i "s/\(BaseImage\s*\=\s*\) \(.*\)/\1 ${CLOOP_NAME}.cloop/" $STARTCONF
 
     # Imageverteilung via rsync oder ist bittorrent enabled?
     BITTORRENT_ON=$(grep START_BTTRACK /etc/default/bittorrent  | awk -F= '{print $2}')
@@ -342,39 +324,42 @@ function configure_cloop {
 
     echo "INFO: Erstelle postsync aus Vorlage"
     # postsync aus vorlage holen
-    POSTSYNC=$CONF_LINBODIR/$1.postsync
+    POSTSYNC=$CONF_LINBODIR/${CLOOP_NAME}.cloop.postsync
     cp $CONF_GENERIC_POSTSYNC/generic.postsync $POSTSYNC
 
-    if [ $CONF_HOSTGROUP_AS_PATCHCLASS != 0 ]; then 
-        # Patchklasse aus config und Kommandozeile wird überschrieben
-        # wenn die Konfiguration die Hostgruppe als Patchklasse erzwingt
-        echo "WARN: Konfiguration erzwingt Hardwareklasse als Patchklasse"
-        PATCHCLASS=$HWCLASS
-    fi
-    echo "INFO: Patchclasse ist $PATCHCLASS"
+#    if [ $CONF_HOSTGROUP_AS_PATCHCLASS != 0 ]; then 
+#        # Patchklasse aus config und Kommandozeile wird überschrieben
+#        # wenn die Konfiguration die Hostgruppe als Patchklasse erzwingt
+#        echo "WARN: Konfiguration erzwingt Hardwareklasse als Patchklasse"
+#        PATCHCLASS=$HOSTGROUP
+#    fi
+
+    PATCHCLASS=$HOSTGROUP
+    echo "INFO: Patchklasse ist $PATCHCLASS"
 
     # Gibt es das Patchklassenverzeichnise schon?
     # Wenn ja: Sichern!
-    if [ -d /var/linbo/linuxmuster-client/$PATCHCLASS ]; then 
+    if [ -d ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS ]; then 
         echo "WARN: Sichere das vorhandene Patchklassenverzeichnis"
-        echo "      /var/linbo/linuxmuster-client/$PATCHCLASS  nach"
-        echo "      /var/linbo/linuxmuster-client/$PATCHCLASS.$ts.autobackup"
-        mv /var/linbo/linuxmuster-client/$PATCHCLASS /var/linbo/linuxmuster-client/$PATCHCLASS.$ts.autobackup
+        echo "      ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS  nach"
+        echo "      ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS.$ts.autobackup"
+        mv ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS.$ts.autobackup
     fi
 
-    mkdir -p /var/linbo/linuxmuster-client/$PATCHCLASS/common/
-    cp -ar $CONF_GENERIC_POSTSYNC/generic.postsync.d /var/linbo/linuxmuster-client/$PATCHCLASS/common/postsync.d
+    mkdir -p ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS/common/
+    cp -ar $CONF_GENERIC_POSTSYNC/generic.postsync.d ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS/common/postsync.d
     sed -i "s/\(PATCHCLASS\s*\=\s*\)\(.*\)/\1\"$PATCHCLASS\"/" $POSTSYNC
 
     # Netzwerksettings in den postsync-pfad
-    mkdir -p /var/linbo/linuxmuster-client/$PATCHCLASS/common/etc/linuxmuster-client/
-    cp  /var/lib/linuxmuster/network.settings /var/linbo/linuxmuster-client/$PATCHCLASS/common/etc/linuxmuster-client/server.network.settings
+    mkdir -p ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS/common/etc/linuxmuster-client/
+    cp  /var/lib/linuxmuster/network.settings ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS/common/etc/linuxmuster-client/server.network.settings
     
     # Passworthash in den postsync-Baum schreiben
     set_password_to_postsync $PATCHCLASS
  
     # public-key des Server-roots in die authorized keys der client roots
-    mkdir -p  /var/linbo/linuxmuster-client/$PATCHCLASS/common/root/.ssh
-    cat /root/.ssh/id_dsa.pub > /var/linbo/linuxmuster-client/$PATCHCLASS/common/root/.ssh/authorized_keys
+    mkdir -p  ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS/common/root/.ssh
+    cat /root/.ssh/id_*.pub > ${CONF_LINBODIR}/${CONF_POSTSYNCDIR}/$PATCHCLASS/common/root/.ssh/authorized_keys
     
+    colorecho "green" "Success"
 }


### PR DESCRIPTION
 * Added consolidate -H (remove -h)
 * Added wget -c to continue downloads
 * Added -f to force overwrite files
 * Renamed the option -l to -p for password
 * Hiding the option to set the password alone
 * Added checking of the md5sums
 * Removed update-available, unnecessary as command
 * Rename variable HWCLASS to HOSTGROUP consistently
 * Renamed exit1 to exit_error consistently
 * Changed the copying of all ssh-keys to the client
 * Changed the default password to "muster" analogous to the XEN-VMs
 * Changed the encoding to utf-8

Ok. Hi nochmal.
Ich habe diesen PR auf Basis des letzten stands gemacht. Außer dem changelog gab es keinen Konflikt, ich hab die Versionsnummer auf 0.9 heraufgesetzt um mergen zu können.

Fazit für dieses Werk:
* weniger optionen, "linuxmuster-client -a auto -c xenial916" ist die minimalangabe "-a auto" könnte man auch noch wegrationalisieren, hab ich aber nicht gemacht.
* dafür kann man den abgebrochenen download resumen, indem man "-f" verwendet. 
* autobackup wird gemacht
* md5sum werden gecheckt und success oder failed angezeigt.

Habs auf meinem Produktivsystem mit xenial916 getestet. der xenial-qgm funkt nicht, 
trusty714 funktioniert auch.
VG, Tobias